### PR TITLE
Add expected failures, more routes and query instead of params

### DIFF
--- a/database/database.js
+++ b/database/database.js
@@ -144,7 +144,7 @@ module.exports = {
 	FindSourceValue : function(startDate, endDate, collectionName) {
 		var SourceValueModel = require('../models/SourceValues.js')(collectionName);
 		
-		return SourceValueModel.find({createdAt : {'$gte' : startDate, '$lt' : endDate}}).then(function (result) {
+		return SourceValueModel.find({createdAt : {'$gte' : startDate, '$lte' : endDate}}).then(function (result) {
 			return result;
 		}).catch(function(err) {
 			return generateErrorObject("Could not find data specified!");

--- a/routes/routes.js
+++ b/routes/routes.js
@@ -21,16 +21,26 @@ var appRouter = function(app, upload, http, logger) {
 	*	RETURNS: BSON containing the value that was sent.
 	*
 	*/
-	app.get("/extern/update-values/:source/:value", function(req, res) {
+	app.get("/extern/update-values/", function(req, res) {
 		logger.log('debug', "source: " + req.params.source + "\nvalue: " + req.params.value);
+		try {
+			var source = req.query.source; 
+			source = source.replace(/[^A-Za-z0-9]/g, '');
+			var value = req.query.value;
+			
+			var result = databaseHandler.AddSourceValue(JSON.parse(value), source);
+			var response = {};
+			
+			response["result"] = result;
 
-		var result = databaseHandler.AddSourceValue(JSON.parse(req.params.value), req.params.source);
-		var response = {};
-		
-		response["result"] = result;
-
-		logger.log('debug', response);
-		res.status(200).send(response);
+			logger.log('debug', response);
+			res.status(200).send(response);
+		}
+		catch(e) {
+			var response = {};
+			response["result"] = {error: 1, message: "Could not handle the request params"};
+			res.status(400).send(response);
+		}
 	});
 
 
@@ -122,6 +132,7 @@ var appRouter = function(app, upload, http, logger) {
 
 		databaseHandler.GetSourceValueLatest(req.params.sourceURL, req.params.numLimit).then(function(result) {
 											var response = {};
+
 											response["result"] = result;
 
 											logger.log('debug', JSON.stringify(response));
@@ -138,17 +149,25 @@ var appRouter = function(app, upload, http, logger) {
 	*
 	*	RETURNS: BSON containing the result from the search. 
 	*/
-	app.get("/intern/update-values/:sourceURL/:from/:to", function(req, res) {
+	app.get("/intern/update-values/", function(req, res) {
 		logger.log('debug', req.params.sourceURL);
-		databaseHandler.FindSourceValue(new Date(req.params.from), 
-										new Date(req.params.to), 
-										req.params.sourceURL).then(function(result) {
-											var response = {};
-											response["result"] = result;
 
-											logger.log('debug', response);
-											res.status(200).send(response);
-										});
+		try {
+			databaseHandler.FindSourceValue(new Date(req.query.from), 
+											new Date(req.query.to), 
+											req.query.sourceURL).then(function(result) {
+												var response = {};
+
+												response["result"] = result;
+
+												logger.log('debug', response);
+												res.status(200).send(response);
+											});
+		} catch(e) {
+			var response = {};
+			response["result"] = {error: 1, message : "Something went wrong!"};
+			res.status(400).send(response);
+		}
 	});
 
 	/** TESTING **/

--- a/test/routesTest.js
+++ b/test/routesTest.js
@@ -1,6 +1,7 @@
 process.env.NODE_ENV = 'test';
 
 module.exports = function(request) {
+	var responseData = [];
 
 	/* testGET(data)
 	PARAMS: expected a JSON object as parameter, with the following attributes:
@@ -8,6 +9,7 @@ module.exports = function(request) {
 			tests - An array containing different tests, this array contains JSON objects with the attributes: 'param' and 'expectedResponse'
 							params - The parameters to use in the GET request. 
 										Example: {a : 5, b : 7} will add /5/7 to the route
+							query - GET variables, the same example as above will add ?a=5&b=7
 
 							expectedResponse - A JSON object containing all expected values the tested route should return as response
 							   					Example: {A : 8, B : 9} will expect that the response contains a JSON object with AT LEAST A=8 and B=9 as attributes
@@ -28,35 +30,53 @@ module.exports = function(request) {
 		}
 	*/
 	function testGET(data) {
-		describe("Testing route (GET): " + data.route, function() {
+		var tempData = [];
 
-			for (var currentTest in data.tests) {
-				var testCase = data.tests[currentTest];
+		data.tests.forEach(function(testCase) {
 
+			it(testCase.description, function(done) {
 				// Add parameters in such a way that they are added after / in the route
 				var paramsStr = "";
-				for (var i in testCase.params) paramsStr += ("/" + ((typeof testCase.params[i] == 'object') ? JSON.stringify(testCase.params[i]) : testCase.params[i]));
+				if(typeof testCase.params == "object")
+					for (var i in testCase.params) 
+						paramsStr += ("/" + ((typeof testCase.params[i] == 'object') ? JSON.stringify(testCase.params[i]) : testCase.params[i]));
+				if(typeof testCase.query == "object") {
+					paramsStr = "?";
+					for (var i in testCase.query) {
+						if(paramsStr !== "?")	
+							paramsStr += "&";
+						paramsStr += i + "=" + encodeURIComponent(((typeof testCase.query[i] == 'object') ? JSON.stringify(testCase.query[i]) : testCase.query[i]));
+					} 
+				}
 
-				it("- Using: " + paramsStr, function(done) {
-					request
-				        .get(data.route + paramsStr)
-				        .end(function(err, res) {
-				        	res.status.should.equal(200);
-				            res.error.should.equal(false);
-				            res.body.result.should.be.json;
+				request
+			        .get(data.route + paramsStr)
+			        .end(function(err, res) {
+			        	res.status.should.equal(testCase.expectedStatusCode || 200);
 
-				            // Loop trough each property of expectedResponse and check that they are correct
-				            for (var val in testCase.expectedResponse)
-				            	res.body.result[val].should.equal(testCase.expectedResponse[val]);
+			        	// TODO: This should not be an error but maybe a warning that we get an error?
+			            // res.error.should.equal(false);
 
-				            done();
-				        });
-				});
-			}
+			            res.body.result.should.be.json;
 
+			            // Loop trough each property of expectedResponse and check that they are correct
+			            for (var val in testCase.expectedResponse) {
+			            	if (typeof testCase.expectedResponse[val] == "undefined")
+			            		res.body.result.should.not.have.property(val);
+			            	else
+			            	// if (!res.body.result.hasOwnProperty(val))
+			            	// 	res.body.result.should.have.property(val);
+			            	// else
+			            		res.body.result[val].should.eql(testCase.expectedResponse[val]);
+			            }
+
+			            testCase.result = res.body.result;
+			            testCase.error = err;
+			            done();
+			        });
+			});
 		});
 	}
-
 
 	/* testPOST(data)
 	PARAMS: expected a JSON object as parameter, with the following attributes:
@@ -95,32 +115,108 @@ module.exports = function(request) {
 		});
 	}
 
-	testGET({
+	// --------------------------
+	// TEST ROUTE #1
+	// --------------------------
+	// Tests for /extern/update-values
+	var updateValuesTestData = {
 		route : "/extern/update-values",
 		tests: [{
-				params : {source : "wwwtestse", data : {value:"FunnyValuez"}},
-				expectedResponse : {value:"FunnyValuez"}
-				},
+			description : "Testing a regular value without spaces",
+			query: {source: "wwwtestse", value : {value:"FunnyValuez"}},
+			expectedResponse : {value:"FunnyValuez"}
+		},
+		{
+			description : "Testing a sentence with spaces and some special chars",
+			query: {source: "wwwtestse", value : {value:"A random sentence with some random words! :)"}},
+			expectedResponse : {value:"A random sentence with some random words! :)"}
+		},
+		{
+			description : "Testing a value containing numbers without spaces",
+			query: {source: "wwwtestse", value : {value:"0001000593827123"}},
+			expectedResponse : {value:"0001000593827123"}
+		},
+		{
+			description : "Mixing words, special chars and swedish characters",
+			query: {source: "wwwtestse", value : {value:"Mixing some words (åäö) and numbers like 010 43824 19!## - -"}},
+			expectedResponse : {value:"Mixing some words (åäö) and numbers like 010 43824 19!## - -"}
+		},
+		{
+			description : "Empty value",
+			query: {source: "wwwtestse", value : {value:""}},
+			expectedResponse : {value:""}
+		},
+		{
+			description : "Empty spaces in value",
+			query: {source: "wwwtestse", value : {value:"      "}},
+			expectedResponse : {value:"      "}
+		},
+		{
+			description : "Using collection name containing special chars",
+			query: {source: "www.test.se", value: {value:"Collection named with special characters like a URL"}},
+			expectedResponse : {value:"Collection named with special characters like a URL"}
+		},
+		{
+			description : "No value attribute specified",
+			query: {source: "wwwtestse"},
+			expectedResponse : {error: 1},
+			expectedStatusCode: 400
+		},
+		{
+			description : "No query variables/attributes specified at all (no source or value)",
+			query: {},
+			expectedResponse : {error: 1},
+			expectedStatusCode: 400
+		}]
+	};
 
-				{
-				params : {source : "wwwtestse", data : {value:"A"}},
-				expectedResponse : {value:"A"}
-				}
-			]
+	describe("Testing route (GET): /extern/update-values", function () {
+		testGET(updateValuesTestData);
 	});
 
 
-	testPOST({
-		route : "/addition",
-		tests: [{
-			 	params : {num1 : 15, num2 : 25},
-			  	expectedResponse : {result : 15+25}
-			  	},
-			  
-			  	{
-			  	params : {num1 : 77, num2 : 11},
-				expectedResponse : {result : 77+11}
-				}
-			]
+
+	// --------------------------
+	// TEST ROUTE #2
+	// --------------------------
+	// Tests for /intern/update-values
+	describe("Testing route (GET): /intern/update-values", function () {
+		var updateValuesTestDataIntern = {
+			route : "/intern/update-values",
+			tests: [{
+				description : "Check that all values from previous tests is returned in specified date range",
+				query : {sourceURL : "wwwtestse", from : "", to : ""},
+				expectedResponse : {}
+			}]
+		};
+
+		before(function(done) {
+			// Get all createdAt responses from the last test
+			responseData = updateValuesTestData.tests.filter(function (test) {
+				return !test.result.error;
+			})
+			.map(function(test) {
+				return test.result;
+			});
+			createdDates = responseData.map(function (test) {
+				return new Date(test.createdAt);
+			});
+
+			// Need to set some attributes of the test data here
+			updateValuesTestDataIntern.tests.forEach(function (test) {
+				test.expectedResponse = responseData;
+				var dateFrom = new Date(Math.min.apply(null, createdDates));
+				var dateTo = new Date(Math.max.apply(null, createdDates));
+				test.query.from = dateFrom.toISOString();
+				test.query.to = dateTo.toISOString();
+			});
+
+			done();
+		});
+
+		testGET(updateValuesTestDataIntern);
 	});
+
+
+	// Quick-TODO: Clear the wwwtestse table so it doesn't persist after test is done?
 }


### PR DESCRIPTION
Now expected failures can be asserted by specifying error: 1 as expectedResponse
Another route is added for test, but for now generates an error because it can't find value
Some routes use GET variables instead of params

The last changes was sloppily added in case we need something to demo later and since this haven't been pushed before. There were some problems that was quickly fixed, so testing of the new code has been poor.

Ohwells, the last test case is supposed to fail.