### PR TITLE
Git server init

### DIFF
--- a/git-server.js
+++ b/git-server.js
@@ -1,0 +1,38 @@
+// Include all the modules requeired
+var express = require('express');
+var child_process = require('child_process');
+var fs = require('fs');
+
+// The path to the git repositories locally on this machine
+const git_path = (process.env.GIT_REPOS_PATH || '/opt/git/');
+
+// Instantiate the git server with this command:
+//  git daemon --export-all --base-path=/opt/git/
+const git_daemon = child_process.spawn('git', ['daemon', '--export-all', '--base-path=' + git_path]);
+
+git_daemon.stdout.on('data', function(data) {
+	console.log(data); // Log something if the git server says something
+});
+git_daemon.stderr.on('data', function(data) {
+	console.log(data); // Log something if the git reserer has errors
+});
+
+// This is our server app
+var app = express();
+
+// This request returns a list of all available repositories
+app.get('/repos', function(request, response) {
+	var repos = fs.readdirSync(git_path);
+	var host = request.conn
+	// Respond with a similar json object as the github api does but only the parameters we need
+	response.end(JSON.stringify(repos.map(function(repo) {
+		return {
+			// The full repository name
+			full_name: 'pi-' + repo,
+			// html url to enable cloning of the repo
+			html_url: 'git://' + request.get('host').split(':')[0] + '/' + repo
+		};
+	})));
+});
+
+app.listen(process.env.LISTEN_PORT || 3000);


### PR DESCRIPTION
This will enable us to do as many requests as possible and still maintain the same datastructure of the github-api and thereby be able to switch between the two servers to install plugins from. This would be possible in the future to merge with our app.js file so that we get one entry point server for everything (git server is still handling the repositories but no installation is required). 

In this pull request you are able to clone and list all repos on the server!